### PR TITLE
Make devcontainer use local gpg folder

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,4 +6,6 @@ RUN apt-get update -y && \
     apt-get upgrade -y && \
     apt-get install gcc-mingw-w64-x86-64 python -y
 
+RUN rustup target add x86_64-pc-windows-gnu 
+
 USER vscode

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/rust
 {
+	"$schema": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.base.schema.json",
 	"name": "Rust",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"build": {
@@ -8,13 +9,18 @@
 	},
 
 	// Use 'mounts' to make the cargo cache persistent in a Docker Volume.
-	// "mounts": [
-	// 	{
-	// 		"source": "devcontainer-cargo-cache-${devcontainerId}",
-	// 		"target": "/usr/local/cargo",
-	// 		"type": "volume"
-	// 	}
-	// ]
+	"mounts": [
+		{
+			"source": "devcontainer-cargo-cache-${devcontainerId}",
+			"target": "/usr/local/cargo",
+			"type": "volume"
+		},
+		{
+			"source": "${localEnv:HOME}${localEnv:USERPROFILE}/.gnupg",
+			"target": "/home/vscode/.gnupg",
+			"type": "bind"
+		}
+	],
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
@@ -23,7 +29,7 @@
 	"forwardPorts": [ 8000 ],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "rustup target add x86_64-pc-windows-gnu && rustc --version"
+	"postCreateCommand": "rustc --version"
 
 	// Configure tool-specific properties.
 	// "customizations": {},


### PR DESCRIPTION
- Makes devcontainer use a docker volume for the cache, should speed up rebuilds of the dev container
- Mounts ~/.gnupg to /home/vscode/.gnupg
- Moves `rustup target add x86_64-pc-windows-gnu` to the image rather than doing it everytime a container is created.